### PR TITLE
Minimize dependencies on Mac-specific files

### DIFF
--- a/fmpsd/classes/FMABR.h
+++ b/fmpsd/classes/FMABR.h
@@ -33,7 +33,7 @@
 @property (assign) CGFloat roundness;
 @property (assign) CGFloat hardness;
 @property (assign) CGFloat scatterJitter;
-@property (assign) uint32 blendMode;
+@property (assign) uint32_t blendMode;
 @property (assign) BOOL computed;
 
 - (void)setImage:(CGImageRef)image;

--- a/fmpsd/classes/FMABR.h
+++ b/fmpsd/classes/FMABR.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <CoreGraphics/CoreGraphics.h>
 
 @class FMPSDDescriptor;
 

--- a/fmpsd/classes/FMABR.m
+++ b/fmpsd/classes/FMABR.m
@@ -15,9 +15,9 @@ extern BOOL FMPSDPrintDebugInfo;
 
 @interface FMABR ()
 
-@property (assign) uint16 version;
-@property (assign) uint16 versionVersion;
-@property (assign) uint16 numberOfBrushes;
+@property (assign) uint16_t version;
+@property (assign) uint16_t versionVersion;
+@property (assign) uint16_t numberOfBrushes;
 
 @end
 
@@ -122,13 +122,13 @@ extern BOOL FMPSDPrintDebugInfo;
     
     _versionVersion = _numberOfBrushes; // it's a version of the version.
     
-    uint32 sig;
+    uint32_t sig;
     FMPSDCheckSig('8BIM', sig, stream, err);
     FMPSDCheckSig('samp', sig, stream, err);
     
     // skip through all the data to find the number of brushes.
     _numberOfBrushes = 0;
-    uint32 length = [stream readInt32];
+    uint32_t length = [stream readInt32];
     long currentPosition = [stream location];
     
     long endPosition = currentPosition + length;
@@ -136,7 +136,7 @@ extern BOOL FMPSDPrintDebugInfo;
     FMPSDDebug(@"Finding brush count");
     
     while ([stream hasLengthToRead:0] && [stream location] < endPosition) {
-        uint32 brushSize = [stream readInt32];
+        uint32_t brushSize = [stream readInt32];
         
         // pad it to a multiple of 4
         brushSize = (brushSize + (3)) & ~0x03;
@@ -149,7 +149,7 @@ extern BOOL FMPSDPrintDebugInfo;
     
     [stream seekToLocation:currentPosition];
     
-    for (uint16 idx = 0; idx < _numberOfBrushes; idx++) {
+    for (uint16_t idx = 0; idx < _numberOfBrushes; idx++) {
         
         FMPSDDebug(@"Attempting to load brush %d at location %ld", idx, [stream location]);
         
@@ -165,7 +165,7 @@ extern BOOL FMPSDPrintDebugInfo;
     FMPSDCheckSig('8BIM', sig, stream, err);
     FMPSDCheckSig('patt', sig, stream, err);
     
-    uint32 patternInfoLength = [stream readInt32];
+    uint32_t patternInfoLength = [stream readInt32];
     [stream skipLength:patternInfoLength];
     
     FMPSDCheckSig('8BIM', sig, stream, err);
@@ -177,7 +177,7 @@ extern BOOL FMPSDPrintDebugInfo;
     FMPSDCheckSig('Brsh', sig, stream, err);
     FMPSDCheckSig('VlLs', sig, stream, err);
     
-    uint32 brushInfoSectionCount = [stream readSInt32];
+    uint32_t brushInfoSectionCount = [stream readSInt32];
     
     for (NSUInteger i = 0; i < brushInfoSectionCount; i++) {
         
@@ -234,13 +234,13 @@ extern BOOL FMPSDPrintDebugInfo;
     
     FMPSBrush *brush = [FMPSBrush new];
     
-    uint32 sectionLength = [stream readInt32];
+    uint32_t sectionLength = [stream readInt32];
     
     sectionLength = (sectionLength + (3)) & ~0x03;
     
     long brushEndLocation = [stream location] + sectionLength;
     
-    uint8 stringLength = [stream readInt8];
+    uint8_t stringLength = [stream readInt8];
     assert(stringLength == 36);
     
     NSString *idString = [stream readPSDStringOfLength:stringLength];
@@ -276,8 +276,8 @@ extern BOOL FMPSDPrintDebugInfo;
     size_t l = [stream readInt32];
     size_t b = [stream readInt32];
     size_t r = [stream readInt32];
-    uint16 depth = [stream readInt16];
-    uint8 compressionType  = [stream readInt8];
+    uint16_t depth = [stream readInt16];
+    uint8_t compressionType  = [stream readInt8];
     
     FMPSDDebug(@"%d %d %d %d, depth: %d, comp: %d", t, l, b, r, depth, compressionType);
     
@@ -297,7 +297,7 @@ extern BOOL FMPSDPrintDebugInfo;
     else {
         // better be rle.
         
-        uint16 *lineLengths  = [[NSMutableData dataWithLength:sizeof(uint16) * height] mutableBytes];
+        uint16_t *lineLengths  = [[NSMutableData dataWithLength:sizeof(uint16_t) * height] mutableBytes];
         
         for (size_t i = 0; i < height; i++) {
             lineLengths[i] = [stream readInt16];
@@ -310,8 +310,8 @@ extern BOOL FMPSDPrintDebugInfo;
         
         int pos = 0;
         int lineIndex = 0;
-        for (uint32 i = 0; i < height; i++) {
-            uint16 len = lineLengths[lineIndex++];
+        for (uint32_t i = 0; i < height; i++) {
+            uint16_t len = lineLengths[lineIndex++];
             
             FMAssert(!(len > (width * 2)));
             

--- a/fmpsd/classes/FMPSD.h
+++ b/fmpsd/classes/FMPSD.h
@@ -26,7 +26,7 @@
 
 #define TSDebug(...) { if (TSDebugOn) { NSLog(__VA_ARGS__); } }
 
-enum {
+typedef enum {
     FMPSDBitmapMode = 0,
     FMPSDGrayscaleMode = 1,
     FMPSDIndexedMode = 2,
@@ -38,7 +38,7 @@ enum {
 } FMPSDMode;
 
 
-enum {
+typedef enum {
     FMPSDLayerTypeNormal,
     FMPSDLayerTypeFolder,
     FMPSDLayerTypeHidden

--- a/fmpsd/classes/FMPSD.h
+++ b/fmpsd/classes/FMPSD.h
@@ -8,8 +8,8 @@
 
 #define NS_BUILD_32_LIKE_64 1
 
-#import <Cocoa/Cocoa.h>
-#import <ApplicationServices/ApplicationServices.h>
+#import <Foundation/Foundation.h>
+#import <CoreImage/CoreImage.h>
 #import <Accelerate/Accelerate.h>
 #import "FMPSDLayer.h"
 

--- a/fmpsd/classes/FMPSD.m
+++ b/fmpsd/classes/FMPSD.m
@@ -10,6 +10,7 @@
 #import "FMPSD.h"
 #import "FMPSDStream.h"
 #import "FMPSDUtils.h"
+#import <ImageIO/ImageIO.h>
 #import <QuartzCore/QuartzCore.h>
 
 BOOL FMPSDPrintDebugInfo = NO;

--- a/fmpsd/classes/FMPSD.m
+++ b/fmpsd/classes/FMPSD.m
@@ -397,7 +397,7 @@ BOOL FMPSDPrintDebugInfo = NO;
     
     FMPSDDebug(@"location when reading in composite: %ld", [stream location]);
     
-    FMPSDLayer *layer = [FMPSDLayer layerWithSize:NSMakeSize(_width, _height) psd:self];
+    FMPSDLayer *layer = [FMPSDLayer layerWithSize:CGSizeMake(_width, _height) psd:self];
     
     [layer setChannels:_channels];
     [layer setupChannelIdsForCompositeRead];
@@ -526,7 +526,7 @@ BOOL FMPSDPrintDebugInfo = NO;
     [stream writeDataWithLengthHeader:[layerAndGlobalMaskStream outputData]];
     layerAndGlobalMaskStream = nil;
     
-    FMPSDLayer *composite = [FMPSDLayer layerWithSize:NSMakeSize(_width, _height) psd:self];
+    FMPSDLayer *composite = [FMPSDLayer layerWithSize:CGSizeMake(_width, _height) psd:self];
     
     if (_savingCompositeImageRef) {
         [composite setImage:_savingCompositeImageRef];
@@ -574,7 +574,7 @@ BOOL FMPSDPrintDebugInfo = NO;
 
 - (CIImage*)compositeCIImage {
     
-    CIImage *i = [[CIImage emptyImage] imageByCroppingToRect:NSMakeRect(0, 0, _width, _height)];
+    CIImage *i = [[CIImage emptyImage] imageByCroppingToRect:CGRectMake(0, 0, _width, _height)];
     
     
     CIFilter *sourceOver = [CIFilter filterWithName:@"CISourceOverCompositing"];

--- a/fmpsd/classes/FMPSD.m
+++ b/fmpsd/classes/FMPSD.m
@@ -191,7 +191,7 @@ BOOL FMPSDPrintDebugInfo = NO;
     }
     
     // make sure it's a psd file, or at least has the right signature.
-    uint32 sig;
+    uint32_t sig;
     if ((sig = [stream readInt32]) != '8BPS') {
         
         NSString *s = [NSString stringWithFormat:@"%s:%d invalid start signature '%@'", __FUNCTION__, __LINE__, FMPSDStringForHFSTypeCode(sig)];
@@ -234,14 +234,14 @@ BOOL FMPSDPrintDebugInfo = NO;
         return NO;
     }
     
-    uint32 colorMapLen = [stream readInt32];
+    uint32_t colorMapLen = [stream readInt32];
     _colormapData = [stream readDataOfLength:colorMapLen];
     
     
     FMPSDDebug(@"colorMapLen: %d", colorMapLen);
     
     // we're reading in the resource bits for the PSD file
-    uint32 length = [stream readInt32];
+    uint32_t length = [stream readInt32];
     long endLoc   = [stream location] + length;
     
     FMPSDDebug(@"doc resource length: %d", length);
@@ -253,11 +253,11 @@ BOOL FMPSDPrintDebugInfo = NO;
                 
         FMPSDCheck8BIMSig(sig, stream, err);
         
-        uint16 uID  = [stream readInt16];
+        uint16_t uID  = [stream readInt16];
         NSString *s = [stream readPascalString];
         
         // Actual size of resource data that follows
-        uint32 sizeofdata = [stream readInt32];
+        uint32_t sizeofdata = [stream readInt32];
         
         FMPSDDebug(@" + %d '%@' len: %d", uID, s, sizeofdata);
         
@@ -284,14 +284,14 @@ BOOL FMPSDPrintDebugInfo = NO;
     FMAssert(endLoc == [stream location]);
     
     // Layer and Mask Information Section
-    uint32 layerAndMaskInformationSectionLength = [stream readInt32];
+    uint32_t layerAndMaskInformationSectionLength = [stream readInt32];
     long pos = [stream location];
     
     FMPSDDebug(@"layer and mask info length: %d", layerAndMaskInformationSectionLength);
     
     if (layerAndMaskInformationSectionLength > 0) {
         
-        uint32 layerInfoLen = [stream readInt32]; // Length of the layers info section, rounded up to a multiple of 2
+        uint32_t layerInfoLen = [stream readInt32]; // Length of the layers info section, rounded up to a multiple of 2
         
         if ((layerInfoLen & 0x01) != 0) {
             layerInfoLen++;
@@ -301,7 +301,7 @@ BOOL FMPSDPrintDebugInfo = NO;
         
         if (layerInfoLen > 0) {
             
-            sint16 layerCt = [stream readInt16]; // Layer count. If it is a negative number, its absolute value is the number of layers and the first alpha channel contains the transparency data for the merged result.
+            int16_t layerCt = [stream readInt16]; // Layer count. If it is a negative number, its absolute value is the number of layers and the first alpha channel contains the transparency data for the merged result.
             
             layerCt = abs(layerCt);
             
@@ -408,10 +408,10 @@ BOOL FMPSDPrintDebugInfo = NO;
     FMPSDDebug(@"rle composite: %d", rle);
     
     if (rle) {
-        uint32 nLines = _height * _channels;
-        uint16 *lineLengths = malloc(sizeof(uint16) * nLines);
+        uint32_t nLines = _height * _channels;
+        uint16_t *lineLengths = malloc(sizeof(uint16_t) * nLines);
         
-        for (uint32 i = 0; i < nLines; i++) {
+        for (uint32_t i = 0; i < nLines; i++) {
             lineLengths[i] = [stream readInt16];
         }
         

--- a/fmpsd/classes/FMPSDCIFilters.h
+++ b/fmpsd/classes/FMPSDCIFilters.h
@@ -6,7 +6,8 @@
 //  Copyright 2010 Flying Meat Inc. All rights reserved.
 //
 
-#import <Cocoa/Cocoa.h>
+#import <Foundation/Foundation.h>
+#import <CoreImage/CoreImage.h>
 
 #import <QuartzCore/QuartzCore.h>
 

--- a/fmpsd/classes/FMPSDCIFilters.m
+++ b/fmpsd/classes/FMPSDCIFilters.m
@@ -42,9 +42,16 @@ static CIKernel *FMPSDAlphaFilterKernel = nil;
 }
 
 - (CIImage *)outputImage {
+#if TARGET_OS_IPHONE    
+        // FYI: this API also is available on 10.11 and later on Mac OS X
+    return [FMPSDAlphaFilterKernel applyWithExtent:_inputImage.extent
+                                       roiCallback:^CGRect(int index, CGRect destRect) { return destRect; }
+                                         arguments:@[_inputImage, _alpha]];
+#else
     CISampler *src = [CISampler samplerWithImage:_inputImage];
     
     return [self apply:FMPSDAlphaFilterKernel, src, _alpha, nil];
+#endif
 }
 
 

--- a/fmpsd/classes/FMPSDDescriptor.h
+++ b/fmpsd/classes/FMPSDDescriptor.h
@@ -6,7 +6,7 @@
 //  Copyright 2010 Flying Meat Inc. All rights reserved.
 //
 
-#import <Cocoa/Cocoa.h>
+#import <Foundation/Foundation.h>
 #import "FMPSDStream.h"
 
 @class FMPSD;

--- a/fmpsd/classes/FMPSDDescriptor.h
+++ b/fmpsd/classes/FMPSDDescriptor.h
@@ -18,10 +18,10 @@
 @property (strong) NSMutableDictionary *attributes;
 
 @property (strong) NSString *name;
-@property (assign) uint32 classId;
+@property (assign) uint32_t classId;
 @property (strong) NSString *classIdString;
 
-@property (assign) uint32 itemCount;
+@property (assign) uint32_t itemCount;
 
 @property (strong) NSMutableArray *items;
 

--- a/fmpsd/classes/FMPSDDescriptor.m
+++ b/fmpsd/classes/FMPSDDescriptor.m
@@ -66,24 +66,24 @@
     }
     
     // ClassID: 4 bytes (length), followed either by string or (if length is zero) 4-byte classID
-    uint32 enumClassID;
+    uint32_t enumClassID;
     NSString *enumClassIDString   = [stream readPSDStringOrGetFourByteID:&enumClassID];
     
     debug(@"enumClassIDString: '%@'", enumClassIDString);
     debug(@"enumClassID: %@", FMPSDStringForHFSTypeCode(enumClassID));
     
     // TypeID: 4 bytes (length), followed either by string or (if length is zero) 4-byte typeID
-    uint32 enumTypeID;
+    uint32_t enumTypeID;
     NSString *enumTypeIDString   = [stream readPSDStringOrGetFourByteID:&enumTypeID];
     
     debug(@"enumTypeIDString: '%@'", enumTypeIDString);
     debug(@"enumTypeID: %@", FMPSDStringForHFSTypeCode(enumTypeID));
     
     // enum: 4 bytes (length), followed either by string or (if length is zero) 4-byte enum
-    uint32 enumMarker = [stream readInt32];
+    uint32_t enumMarker = [stream readInt32];
     FMAssert(enumMarker == 'enum');
     
-    uint32 enumValue;
+    uint32_t enumValue;
     NSString *enumValueString   = [stream readPSDStringOrGetFourByteID:&enumValue];
     
     debug(@"enumValueString: '%@'", enumValueString);
@@ -124,17 +124,17 @@
      00005490  09 3c 3c 0a 09 09 09 2f  44 65 66 61 75 6c 74 52  |.<<..../DefaultR|
      */
      
-    for (uint32 i = 0; i < _itemCount; i++) {
+    for (uint32_t i = 0; i < _itemCount; i++) {
         
         //debug(@"reading key/type #%d at offset %ld", i+1, [stream location]);
         
         // Key: 4 bytes ( length) followed either by string or (if length is zero) 4-byte key
-        uint32 type = 0;
+        uint32_t type = 0;
         NSString *key = [stream readPSDStringOrGetFourByteID:&type];
         
         if (type == 'Txt ') {
             
-            uint32 textTag = [stream readInt32];
+            uint32_t textTag = [stream readInt32];
             FMAssert(textTag == 'TEXT');
             
             NSString *layerText = [stream readPSDString16];
@@ -150,7 +150,7 @@
             [self readEnumFromStream:stream];
         }
         else if (type == 'long') {
-            uint32 val = [stream readInt32];
+            uint32_t val = [stream readInt32];
             #pragma unused(val)
             //debug(@"Long val: %d", val);
         }
@@ -161,7 +161,7 @@
         }
         else if (type == 'tdta') {
             
-            uint32 size = [stream readInt32];
+            uint32_t size = [stream readInt32];
             [stream skipLength:size];
         }
         else if (type == 'Objc') {
@@ -170,10 +170,10 @@
         else if (type == 'Ornt') {
             
             
-            uint32 enumTag = [stream readInt32];
+            uint32_t enumTag = [stream readInt32];
             FMAssert(enumTag == 'enum');
             
-            uint32 junkIntKey = 0;
+            uint32_t junkIntKey = 0;
             NSString *junkStringKey = [stream readPSDStringOrGetFourByteID:&junkIntKey];
             (void)junkStringKey; // shh, clang-sa, I know.
             
@@ -188,10 +188,10 @@
         }
         else if (type == 'AntA') {
             
-            uint32 enumTag = [stream readInt32];
+            uint32_t enumTag = [stream readInt32];
             FMAssert(enumTag == 'enum');
             
-            uint32 junkIntKey = 0;
+            uint32_t junkIntKey = 0;
             NSString *junkStringKey = [stream readPSDStringOrGetFourByteID:&junkIntKey];
             (void)junkStringKey; // shh, clang-sa, I know.
             
@@ -209,7 +209,7 @@
         else if ([key isEqualToString:@"textGridding"]) {
             FMAssert(!type);
             
-            uint32 enumTag = [stream readInt32];
+            uint32_t enumTag = [stream readInt32];
             FMAssert(enumTag == 'enum');
             
             NSString *textGriddingString = [stream readPSDString];
@@ -225,7 +225,7 @@
         }
         else if ([key isEqualToString:@"bounds"] || [key isEqualToString:@"boundingBox"]) {
             
-            uint32 boundsKey = [stream readInt32];
+            uint32_t boundsKey = [stream readInt32];
             
             FMAssert(boundsKey == 'Objc');
             
@@ -265,10 +265,10 @@
         
         else if ([key isEqualToString:@"warpStyle"] || [key isEqualToString:@"warpRotate"]) {
             
-            uint32 enumTag = [stream readInt32];
+            uint32_t enumTag = [stream readInt32];
             FMAssert(enumTag == 'enum');
             
-            uint32 junkIntKey = 0;
+            uint32_t junkIntKey = 0;
             NSString *junkStringKey = [stream readPSDStringOrGetFourByteID:&junkIntKey]; // Ornt for warpRotate - "warpStyle" for warpStyle.
             (void)junkStringKey; // shh, clang-sa, I know.
             
@@ -280,7 +280,7 @@
         }
         else if ([key isEqualToString:@"warpValue"] || [key isEqualToString:@"warpPerspective"] || [key isEqualToString:@"warpPerspectiveOther"]) {
             
-            uint32 enumTag = [stream readInt32];
+            uint32_t enumTag = [stream readInt32];
             FMAssert(enumTag == 'doub');
             
             double val = [stream readDouble64];
@@ -301,12 +301,12 @@
         }
         else if ([key isEqualToString:@"EngineData"]) {
             
-            uint32 tdtaTag = [stream readInt32];
+            uint32_t tdtaTag = [stream readInt32];
             FMAssert(tdtaTag == 'tdta');
             
             debug(@"[stream location]: %ld", [stream location]);
             
-            uint32 textPropertiesLength = [stream readInt32];
+            uint32_t textPropertiesLength = [stream readInt32];
             NSData *textPropertiesData = [stream readDataOfLength:textPropertiesLength];
             
             FMPSDTextEngineParser *parser = [FMPSDTextEngineParser new];
@@ -325,7 +325,7 @@
             //NSLog(@"guessing for %@ / '%@' offset %ld", FMPSDStringForHFSTypeCode(type), key, [stream location]);
             NSString *attKey = key ? key : FMPSDStringForHFSTypeCode(type);
             
-            uint32 tag = [stream readInt32];
+            uint32_t tag = [stream readInt32];
             if (tag == 'bool') {
                 [[self attributes] setObject:@([stream readInt8]) forKey:attKey];
             }
@@ -336,7 +336,7 @@
                 [[self attributes] setObject:@([stream readInt32]) forKey:attKey];
             }
             else if (tag == 'tdta') {
-                uint32 size = [stream readInt32];
+                uint32_t size = [stream readInt32];
                 [stream skipLength:size];
             }
             else if (tag == 'Objc') {
@@ -361,7 +361,7 @@
                  
                  */
                  
-                uint32 unitType = [stream readInt32];
+                uint32_t unitType = [stream readInt32];
                 //NSLog(@"unitType: %@", FMPSDStringForHFSTypeCode(unitType));
                  
                 // #Pnt isn't documented, but I'm going to assume it means "point".
@@ -394,12 +394,12 @@
                 
                 [stream skipLength:4];
                 
-                uint32 blendModeTagAgain = [stream readInt32];
+                uint32_t blendModeTagAgain = [stream readInt32];
                 [stream skipLength:4];
                 
                 FMAssert(blendModeTagAgain == 'BlnM');
                 
-                uint32 blendMode = [stream readInt32];
+                uint32_t blendMode = [stream readInt32];
                 
                 [[self attributes] setObject:FMPSDStringForHFSTypeCode(blendMode) forKey:attKey];
                 

--- a/fmpsd/classes/FMPSDLayer.h
+++ b/fmpsd/classes/FMPSDLayer.h
@@ -6,7 +6,9 @@
 //  Copyright 2010 Flying Meat Inc. All rights reserved.
 //
 
-#import <Cocoa/Cocoa.h>
+#import <Foundation/Foundation.h>
+#import <CoreGraphics/CoreGraphics.h>
+#import <CoreImage/CoreImage.h>
 #import "FMPSDStream.h"
 #import "FMPSDDescriptor.h"
 

--- a/fmpsd/classes/FMPSDLayer.h
+++ b/fmpsd/classes/FMPSDLayer.h
@@ -14,24 +14,24 @@
 
 @interface FMPSDLayer : NSObject {
 
-    sint32 _maskTop;
-    sint32 _maskLeft;
-    sint32 _maskBottom;
-    sint32 _maskRight;
-    sint32 _maskWidth;
-    sint32 _maskHeight;
+    int32_t _maskTop;
+    int32_t _maskLeft;
+    int32_t _maskBottom;
+    int32_t _maskRight;
+    int32_t _maskWidth;
+    int32_t _maskHeight;
     
     
-    sint32 _maskTop2;
-    sint32 _maskLeft2;
-    sint32 _maskBottom2;
-    sint32 _maskRight2;
-    sint32 _maskWidth2;
-    sint32 _maskHeight2;
-    uint8  _maskColor;
+    int32_t _maskTop2;
+    int32_t _maskLeft2;
+    int32_t _maskBottom2;
+    int32_t _maskRight2;
+    int32_t _maskWidth2;
+    int32_t _maskHeight2;
+    uint8_t  _maskColor;
     
-    uint32 _layerId;
-    uint32 _blendMode;
+    uint32_t _layerId;
+    uint32_t _blendMode;
     
     CGImageRef _image;
     CGImageRef _mask;
@@ -40,32 +40,32 @@
     
     BOOL _isBase;
     
-    sint16 _channelIds[10];
-    uint32 _channelLens[10];
+    int16_t _channelIds[10];
+    uint32_t _channelLens[10];
     BOOL _printDebugInfo;
 }
 
-@property (assign) sint32 top;
-@property (assign) sint32 left;
-@property (assign) sint32 bottom;
-@property (assign) sint32 right;
-@property (assign) uint16 channels;
+@property (assign) int32_t top;
+@property (assign) int32_t left;
+@property (assign) int32_t bottom;
+@property (assign) int32_t right;
+@property (assign) uint16_t channels;
 @property (retain) NSString *layerName;
 @property (weak) FMPSD *psd;
 @property (retain) FMPSDDescriptor *textDescriptor;
 @property (assign) BOOL isComposite;
-@property (assign) sint32 width;
-@property (assign) sint32 height;
+@property (assign) int32_t width;
+@property (assign) int32_t height;
 @property (assign) BOOL isGroup;
 @property (assign) BOOL isText;
 @property (retain) NSMutableArray *layers;
-@property (assign) uint32 dividerType;
+@property (assign) uint32_t dividerType;
 @property (weak) FMPSDLayer *parent;
 @property (assign) BOOL visible;
 @property (assign) BOOL transparencyProtected;
-@property (assign) uint8 opacity;
+@property (assign) uint8_t opacity;
 @property (assign) BOOL printDebugInfo;
-@property (assign) uint32 blendMode;
+@property (assign) uint32_t blendMode;
 @property (retain) NSDictionary *textProperties;
 
 
@@ -73,7 +73,7 @@
 + (id)layerWithSize:(NSSize)s psd:(FMPSD*)psd;
 + (id)baseLayer;
 
-- (BOOL)readImageDataFromStream:(FMPSDStream*)stream lineLengths:(uint16 *)lineLengths needReadPlanInfo:(BOOL)needsPlaneInfo error:(NSError *__autoreleasing *)err;
+- (BOOL)readImageDataFromStream:(FMPSDStream*)stream lineLengths:(uint16_t *)lineLengths needReadPlanInfo:(BOOL)needsPlaneInfo error:(NSError *__autoreleasing *)err;
 - (void)writeLayerInfoToStream:(FMPSDStream*)stream;
 - (void)writeImageDataToStream:(FMPSDStream*)stream;
 
@@ -85,7 +85,7 @@
 - (void)setImage:(CGImageRef)anImage;
 - (CGImageRef)mask;
 - (void)setMask:(CGImageRef)value;
-- (uint8)maskColor;
+- (uint8_t)maskColor;
 
 - (CIImage*)CIImageForComposite;
 

--- a/fmpsd/classes/FMPSDLayer.h
+++ b/fmpsd/classes/FMPSDLayer.h
@@ -72,17 +72,17 @@
 
 
 + (id)layerWithStream:(FMPSDStream*)stream psd:(FMPSD*)psd error:(NSError *__autoreleasing *)err;
-+ (id)layerWithSize:(NSSize)s psd:(FMPSD*)psd;
++ (id)layerWithSize:(CGSize)s psd:(FMPSD*)psd;
 + (id)baseLayer;
 
 - (BOOL)readImageDataFromStream:(FMPSDStream*)stream lineLengths:(uint16_t *)lineLengths needReadPlanInfo:(BOOL)needsPlaneInfo error:(NSError *__autoreleasing *)err;
 - (void)writeLayerInfoToStream:(FMPSDStream*)stream;
 - (void)writeImageDataToStream:(FMPSDStream*)stream;
 
-- (NSRect)frame;
-- (void)setFrame:(NSRect)frame;
-- (void)setMaskFrame:(NSRect)frame;
-- (NSRect)maskFrame;
+- (CGRect)frame;
+- (void)setFrame:(CGRect)frame;
+- (void)setMaskFrame:(CGRect)frame;
+- (CGRect)maskFrame;
 - (CGImageRef)image;
 - (void)setImage:(CGImageRef)anImage;
 - (CGImageRef)mask;

--- a/fmpsd/classes/FMPSDLayer.m
+++ b/fmpsd/classes/FMPSDLayer.m
@@ -33,7 +33,7 @@
     return ret;
 }
 
-+ (id)layerWithSize:(NSSize)s psd:(FMPSD*)psd {
++ (id)layerWithSize:(CGSize)s psd:(FMPSD*)psd {
     
     FMPSDLayer *ret = [[self alloc] init];
     [ret setPsd:psd];
@@ -1151,11 +1151,11 @@
     [_layers addObject:layer];
 }
 
-- (NSRect)frame {
-    return NSMakeRect(_left, (float)[_psd height] - (float)_bottom, _width, _height);
+- (CGRect)frame {
+    return CGRectMake(_left, (float)[_psd height] - (float)_bottom, _width, _height);
 }
 
-- (void)setFrame:(NSRect)frame {
+- (void)setFrame:(CGRect)frame {
     
     // the origin is in the top left.
     
@@ -1164,28 +1164,28 @@
     _width              = frame.size.width;
     _height             = frame.size.height;
     
-    _left               = NSMinX(frame);
-    _right              = NSMaxX(frame);
+    _left               = CGRectGetMinX(frame);
+    _right              = CGRectGetMaxX(frame);
         
-    _top                = psdHeight - NSMaxY(frame);
-    _bottom             = psdHeight - NSMinY(frame);
+    _top                = psdHeight - CGRectGetMaxY(frame);
+    _bottom             = psdHeight - CGRectGetMinY(frame);
 }
 
-- (NSRect)maskFrame {
-    return NSMakeRect(_maskLeft, (float)[_psd height] - (float)_maskBottom, _maskWidth, _maskHeight);
+- (CGRect)maskFrame {
+    return CGRectMake(_maskLeft, (float)[_psd height] - (float)_maskBottom, _maskWidth, _maskHeight);
 }
 
-- (void)setMaskFrame:(NSRect)frame {
+- (void)setMaskFrame:(CGRect)frame {
     CGFloat psdHeight   = [_psd height];
     
     _maskWidth  = frame.size.width;
     _maskHeight = frame.size.height;
     
-    _maskLeft   = NSMinX(frame);
-    _maskRight  = NSMaxX(frame);
+    _maskLeft   = CGRectGetMinX(frame);
+    _maskRight  = CGRectGetMaxX(frame);
     
-    _maskTop    = psdHeight - NSMaxY(frame);
-    _maskBottom = psdHeight - NSMinY(frame);
+    _maskTop    = psdHeight - CGRectGetMaxY(frame);
+    _maskBottom = psdHeight - CGRectGetMinY(frame);
 }
 
 
@@ -1200,7 +1200,7 @@
     
     if (_isGroup) {
         
-        CIImage *i = [[CIImage emptyImage] imageByCroppingToRect:NSMakeRect(0, 0, [_psd width], [_psd height])];
+        CIImage *i = [[CIImage emptyImage] imageByCroppingToRect:CGRectMake(0, 0, [_psd width], [_psd height])];
         
         for (FMPSDLayer *layer in [_layers reverseObjectEnumerator]) {
             
@@ -1222,14 +1222,14 @@
     CIImage *img = nil;
     
     if (!_image) {
-        img = [[CIImage emptyImage] imageByCroppingToRect:NSMakeRect(0, 0, _width, _height)];
+        img = [[CIImage emptyImage] imageByCroppingToRect:CGRectMake(0, 0, _width, _height)];
     }
     else {
         img = [CIImage imageWithCGImage:_image];
     }
     
     
-    NSRect r = [self frame];
+    CGRect r = [self frame];
     img = [img imageByApplyingTransform:CGAffineTransformMakeTranslation(r.origin.x, r.origin.y)];
     
     if (_opacity < 255) {
@@ -1245,7 +1245,7 @@
     if (_mask) {
         
         CIImage *maskImage = [CIImage imageWithCGImage:_mask];
-        NSRect maskFrame = [self maskFrame];
+        CGRect maskFrame = [self maskFrame];
         maskImage = [maskImage imageByApplyingTransform:CGAffineTransformMakeTranslation(maskFrame.origin.x, maskFrame.origin.y)];
         
         CIFilter *filter = [CIFilter filterWithName:@"CIColorInvert"];

--- a/fmpsd/classes/FMPSDLayer.m
+++ b/fmpsd/classes/FMPSDLayer.m
@@ -103,7 +103,7 @@
     [stream writeInt8:255]; // opactiy
     [stream writeInt8:0]; //clipping Clipping: 0 = base, 1 = non–base
     
-    uint8 flags = 10;
+    uint8_t flags = 10;
     if (!_transparencyProtected && _visible) {
         flags = 8;
     }
@@ -137,17 +137,17 @@
     
     [extraDataStream writeInt32:'8BIM'];
     [extraDataStream writeInt32:'lsct'];
-    [extraDataStream writeInt32:sizeof(uint32)];
+    [extraDataStream writeInt32:sizeof(uint32_t)];
     [extraDataStream writeInt32:3]; // 3 = FMPSDLayerTypeHidden
     
     [extraDataStream writeInt32:'8BIM'];
     [extraDataStream writeInt32:'luni']; // unicode version of string.
     
     NSRange r = NSMakeRange(0, [groupEndMarkerName length]);
-    [extraDataStream writeInt32:(uint32)(r.length * 2) + 4]; // length of the next bit of data.
+    [extraDataStream writeInt32:(uint32_t)(r.length * 2) + 4]; // length of the next bit of data.
     
     // length of our data as a unicode string.
-    [extraDataStream writeInt32:(uint32)r.length];
+    [extraDataStream writeInt32:(uint32_t)r.length];
     
     unichar *buffer = malloc(sizeof(unichar) * ([groupEndMarkerName length] + 1));
     
@@ -207,7 +207,7 @@
     [stream writeInt8:0]; //clipping Clipping: 0 = base, 1 = non–base
     
     // uint8 f = ((_visible << 0x01) | _transparencyProtected);
-    uint8 flags = 10;
+    uint8_t flags = 10;
     if (!_transparencyProtected && _visible) {
         flags = 8;
     }
@@ -265,10 +265,10 @@
         [extraDataStream writeInt32:'luni']; // unicode version of string.
         
         NSRange r = NSMakeRange(0, [_layerName length]);
-        [extraDataStream writeInt32:(uint32)(r.length * 2) + 4]; // length of the next bit of data.
+        [extraDataStream writeInt32:(uint32_t)(r.length * 2) + 4]; // length of the next bit of data.
         
         // length of our data as a unicode string.
-        [extraDataStream writeInt32:(uint32)r.length];
+        [extraDataStream writeInt32:(uint32_t)r.length];
         
         unichar *buffer = malloc(sizeof(unichar) * ([_layerName length] + 1));
         
@@ -441,7 +441,7 @@
 }
 
 - (BOOL)readLayerInfo:(FMPSDStream*)stream error:(NSError *__autoreleasing *)err {
-    uint32 sig;
+    uint32_t sig;
     
     BOOL success    = YES;
     
@@ -466,8 +466,8 @@
     FMAssert(_channels <= 10);
     
     for (int chCount = 0; chCount < _channels; chCount++) {
-        sint16 chandId = [stream readInt16];
-        uint32 chanLen = [stream readInt32];
+        int16_t chandId = [stream readInt16];
+        uint32_t chanLen = [stream readInt32];
         
         _channelIds[chCount]    = chandId;
         _channelLens[chCount]   = chanLen;
@@ -487,7 +487,7 @@
     
     [stream readInt8]; // uint8 clipping
     
-    uint8 flags = [stream readInt8];
+    uint8_t flags = [stream readInt8];
     
     _transparencyProtected = flags & 0x01;
     _visible = ((flags >> 1) & 0x01) == 0;
@@ -504,11 +504,11 @@
     [stream readInt8]; // filler
     
     
-    uint32 lenOfExtraData     = [stream readInt32]; // 84454 - 2600 len
+    uint32_t lenOfExtraData     = [stream readInt32]; // 84454 - 2600 len
     //lenOfExtraData = (lenOfExtraData % 2 == 0) ? lenOfExtraData : lenOfExtraData + 1;
     //lenOfExtraData = (lenOfExtraData) & ~0x01;
     
-    uint32 foob = lenOfExtraData;
+    uint32_t foob = lenOfExtraData;
     foob = (foob % 2 == 0) ? foob : foob + 1;
     foob = (foob) & ~0x01;
     
@@ -526,7 +526,7 @@
 		// Size of the data: 36, 20, or 0. If zero, the following fields are not
 		// present
         
-        uint32 lenOfMask = [stream readInt32];
+        uint32_t lenOfMask = [stream readInt32];
         
         FMPSDDebug(@"  lenOfMask:              %d", lenOfMask);
         
@@ -538,7 +538,7 @@
             
             
             _maskColor    = [stream readInt8];
-            uint8 lflags    = [stream readInt8];
+            uint8_t lflags    = [stream readInt8];
             
             if (lenOfMask == 20) {
                 [stream skipLength:2];
@@ -576,7 +576,7 @@
         FMPSDDebug(@"location before blend read: %ld", [stream location]);
         
         // Layer blending ranges data
-        uint32 blendLength = [stream readInt32];
+        uint32_t blendLength = [stream readInt32];
         
         // 83446
         if (blendLength == 65535) {
@@ -591,7 +591,7 @@
         
         
         // Layer name: Pascal string, padded to a multiple of 4 bytes.
-        uint8 psize = [stream readInt8];
+        uint8_t psize = [stream readInt8];
         psize = ((psize + 1 + 3) & ~0x03) - 1;
         
         FMPSDDebug(@"Length of layer name is %d", psize);
@@ -609,8 +609,8 @@
         while ([stream location] < startExtraLocation + lenOfExtraData) {
             
             FMPSDCheck8BIMSig(sig, stream, err);
-            uint32 tag  = [stream readInt32];
-            uint32 sigSize = [stream readInt32];
+            uint32_t tag  = [stream readInt32];
+            uint32_t sigSize = [stream readInt32];
             
             // re sigSize: the official docs say "Length data below, rounded up to an even byte count."
             // but that's complete bullshit, as in the case of Adobe Fireworks CS3 spitting out bad data.
@@ -687,7 +687,7 @@
                 // http://www.adobe.com/devnet-apps/photoshop/fileformatashtml/PhotoshopFileFormats.htm#50577409_19762
                 long textStartLocation = [stream location];
                 
-                uint16 version = [stream readInt16];
+                uint16_t version = [stream readInt16];
                 if (version != 1) {
                     NSLog(@"Can't read the text data, we don't understand version %d!", version);
                     return NO;
@@ -702,7 +702,7 @@
                 t.tx = [stream readDouble64];
                 t.ty = [stream readDouble64];
                 
-                uint16 textVersion = [stream readInt16];
+                uint16_t textVersion = [stream readInt16];
                 [stream readInt32]; // descriptorVersion
                 
                 if (textVersion != 50) {
@@ -712,10 +712,10 @@
                 
                 [self setTextDescriptor:[FMPSDDescriptor descriptorWithStream:stream psd:_psd]];
                 
-                uint16 warpVersion = [stream readInt16];
+                uint16_t warpVersion = [stream readInt16];
                 FMAssert(warpVersion == 1);
                 
-                uint32 descriptorVersion = [stream readInt32];
+                uint32_t descriptorVersion = [stream readInt32];
                 FMAssert(descriptorVersion == 16);
                 
                 [FMPSDDescriptor descriptorWithStream:stream psd:_psd];
@@ -756,12 +756,12 @@
 }
 
 
-- (char*)parsePlaneCompressed:(FMPSDStream*)stream lineLengths:(uint16 *)lineLengths planeNum:(int)planeNum isMask:(BOOL)isMask {
+- (char*)parsePlaneCompressed:(FMPSDStream*)stream lineLengths:(uint16_t *)lineLengths planeNum:(int)planeNum isMask:(BOOL)isMask {
     
     //NSLog(@"location at parsePlaneCompressed: %ld for planeNum %d", [stream location], planeNum);
     
-    uint32 width = _width;
-    uint32 height = _height;
+    uint32_t width = _width;
+    uint32_t height = _height;
     
     
     if (isMask) {
@@ -781,8 +781,8 @@
     
     int pos = 0;
     int lineIndex = planeNum * height;
-    for (uint32 i = 0; i < height; i++) {
-        uint16 len = lineLengths[lineIndex++];
+    for (uint32_t i = 0; i < height; i++) {
+        uint16_t len = lineLengths[lineIndex++];
         
         //debug(@"%d: %d", i, len);
         
@@ -799,7 +799,7 @@
     return b;
 }
 
-- (char*)readPlaneFromStream:(FMPSDStream*)stream lineLengths:(uint16 *)lineLengths needReadPlaneInfo:(BOOL)needReadPlaneInfo planeNum:(int)planeNum  error:(NSError *__autoreleasing *)err {
+- (char*)readPlaneFromStream:(FMPSDStream*)stream lineLengths:(uint16_t *)lineLengths needReadPlaneInfo:(BOOL)needReadPlaneInfo planeNum:(int)planeNum  error:(NSError *__autoreleasing *)err {
     
     //BOOL rawImageData           = NO;
     BOOL rleEncoded             = NO;
@@ -810,13 +810,13 @@
     
     //debug(@"planeNum: %d, needReadPlaneInfo? %d", planeNum, needReadPlaneInfo);
     
-    uint32 thisLength = _channelLens[planeNum];
-    sint16 chanId     = _channelIds[planeNum];
+    uint32_t thisLength = _channelLens[planeNum];
+    int16_t chanId     = _channelIds[planeNum];
     
     BOOL isMask       = (chanId == -2);
     
     if (needReadPlaneInfo) {
-        uint16 encoding = [stream readInt16];
+        uint16_t encoding = [stream readInt16];
         
         //debug(@"encoding: %d", encoding);
         //NSLog(@"_channelLens: %d", _channelLens[_channels]);
@@ -881,9 +881,9 @@
         if (rleEncoded) {
             if (lineLengths == nil) {
                 
-                sint32 h = (isMask ? _maskHeight : _height);
+                int32_t h = (isMask ? _maskHeight : _height);
                 
-                lineLengths = [[NSMutableData dataWithLength:sizeof(uint16) * h] mutableBytes];
+                lineLengths = [[NSMutableData dataWithLength:sizeof(uint16_t) * h] mutableBytes];
                 
                 //debug(@"(isMask ? _maskHeight : _height): %d", h);
                 
@@ -907,7 +907,7 @@
         ret = (char*)[self parsePlaneCompressed:stream lineLengths:lineLengths planeNum:planeNum isMask:isMask];
     }
     else {
-        uint32 size = _width * _height;
+        int32_t size = _width * _height;
         
         if (isMask) {
             FMAssert(_maskWidth > 0);
@@ -930,7 +930,7 @@
     return _channelIds[row];
 }
 
-- (BOOL)readImageDataFromStream:(FMPSDStream*)stream lineLengths:(uint16 *)lineLengths needReadPlanInfo:(BOOL)needsPlaneInfo error:(NSError *__autoreleasing *)err {
+- (BOOL)readImageDataFromStream:(FMPSDStream*)stream lineLengths:(uint16_t *)lineLengths needReadPlanInfo:(BOOL)needsPlaneInfo error:(NSError *__autoreleasing *)err {
     
     char* r = nil, *g = nil, *b = nil, *a = nil, *m = nil;
     
@@ -1056,7 +1056,7 @@
             FMPSDPixel *p = &c[_width * row];
             
             size_t planeStart = (row * _width);
-            sint32 x = 0;
+            int32_t x = 0;
             while (x < _width) {
                 
                 size_t planeLoc = planeStart + x;
@@ -1099,7 +1099,7 @@
     return YES;
 }
 
-- (uint8)maskColor {
+- (uint8_t)maskColor {
     return _maskColor;
 }
 
@@ -1111,8 +1111,8 @@
     
     if (anImage) {
         CGImageRetain(anImage);
-        _maskWidth = (uint32)CGImageGetWidth(anImage);
-        _maskHeight = (uint32)CGImageGetHeight(anImage);
+        _maskWidth = (uint32_t)CGImageGetWidth(anImage);
+        _maskHeight = (uint32_t)CGImageGetHeight(anImage);
     }
     
     if (_mask) {

--- a/fmpsd/classes/FMPSDLayer.m
+++ b/fmpsd/classes/FMPSDLayer.m
@@ -12,6 +12,7 @@
 #import "FMPSDCIFilters.h"
 #import "FMPSDTextEngineParser.h"
 #import <Accelerate/Accelerate.h>
+#import <ImageIO/ImageIO.h>
 
 
 @interface FMPSDLayer()

--- a/fmpsd/classes/FMPSDStream.h
+++ b/fmpsd/classes/FMPSDStream.h
@@ -25,16 +25,16 @@
 - (void)close;
 - (NSData*)outputData;
 
-- (uint8)readInt8;
-- (uint16)readInt16;
-- (uint32)readInt32;
-- (sint32)readSInt32;
-- (uint64)readInt64;
+- (uint8_t)readInt8;
+- (uint16_t)readInt16;
+- (uint32_t)readInt32;
+- (int32_t)readSInt32;
+- (uint64_t)readInt64;
 - (double)readDouble64;
 - (NSInteger)readChars:(char *)buffer maxLength:(NSUInteger)len;
 - (NSString*)readPSDString;
-- (NSString*)readPSDStringOfLength:(uint32)size;
-- (NSString*)readPSDStringOrGetFourByteID:(uint32*)outId;
+- (NSString*)readPSDStringOfLength:(uint32_t)size;
+- (NSString*)readPSDStringOrGetFourByteID:(uint32_t*)outId;
 - (NSString*)readPascalString;
 - (NSString*)readPSDString16;
 - (NSMutableData*)readDataOfLength:(NSUInteger)len;
@@ -45,11 +45,11 @@
 - (long)location;
 - (void)seekToLocation:(long)newLocation;
 
-- (void)writeInt64:(uint64)value;
-- (void)writeInt32:(uint32)value;
-- (void)writeInt16:(uint16)value;
-- (void)writeSInt16:(sint16)value;
-- (void)writeInt8:(uint8)value;
+- (void)writeInt64:(uint64_t)value;
+- (void)writeInt32:(uint32_t)value;
+- (void)writeInt16:(uint16_t)value;
+- (void)writeSInt16:(int16_t)value;
+- (void)writeInt8:(uint8_t)value;
 - (void)writeData:(NSData*)data;
 - (void)writeChars:(char*)chars length:(size_t)length;
 - (void)writeDataWithLengthHeader:(NSData*)data;

--- a/fmpsd/classes/FMPSDStream.h
+++ b/fmpsd/classes/FMPSDStream.h
@@ -6,7 +6,7 @@
 //  Copyright 2010 Flying Meat Inc. All rights reserved.
 //
 
-#import <Cocoa/Cocoa.h>
+#import <Foundation/Foundation.h>
 
 
 @interface FMPSDStream : NSObject {

--- a/fmpsd/classes/FMPSDStream.m
+++ b/fmpsd/classes/FMPSDStream.m
@@ -116,19 +116,19 @@
     return len;
 }
 
-- (uint8)readInt8 {
+- (uint8_t)readInt8 {
     
-    uint8 value = 0;
+    uint8_t value = 0;
     
     [self read:&value maxLength:1];
     
     return value;
 }
 
-- (uint16)readInt16 {
+- (uint16_t)readInt16 {
     
     unsigned char buffer[2];
-    uint16 value = 0;
+    uint16_t value = 0;
     
     if ([self read:buffer maxLength:2] == 2) {
         value  = buffer[0] << 8;
@@ -139,10 +139,10 @@
     return value;
 }
 
-- (uint32)readInt32 {
+- (uint32_t)readInt32 {
     
     unsigned char buffer[4];
-    uint32 value = -1;
+    uint32_t value = -1;
     
     if ([self read:buffer maxLength:4] == 4) {
         value  = buffer[0] << 24;
@@ -155,10 +155,10 @@
 }
 
 
-- (sint32)readSInt32 {
+- (int32_t)readSInt32 {
     
     unsigned char buffer[4];
-    sint32 value = -1;
+    int32_t value = -1;
     
     if ([self read:buffer maxLength:4] == 4) {
         value  = buffer[0] << 24;
@@ -174,7 +174,7 @@
     
     CFSwappedFloat64 sf;
     
-    [self read:(uint8*)&sf.v maxLength:8];
+    [self read:(uint8_t*)&sf.v maxLength:8];
     
     double f = CFConvertDoubleSwappedToHost(sf);
     
@@ -182,11 +182,11 @@
 }
 
 
-- (uint64)readInt64 {
+- (uint64_t)readInt64 {
     
-    uint64 value = 0;
+    uint64_t value = 0;
     
-    [self read:(uint8*)&value maxLength:8];
+    [self read:(uint8_t*)&value maxLength:8];
     
 #ifdef __LITTLE_ENDIAN__
     value = CFSwapInt64(value);
@@ -196,12 +196,12 @@
 }
 
 - (NSInteger)readChars:(char *)buffer maxLength:(NSUInteger)len {
-    return [self read:(uint8*)buffer maxLength:len];
+    return [self read:(uint8_t*)buffer maxLength:len];
 }
 
 - (NSString*)readPSDString16 {
     
-    sint32 size = [self readInt32];
+    int32_t size = [self readInt32];
     
     if (size <= 0) {
         return @"";
@@ -209,7 +209,7 @@
     
     unichar *c = malloc(sizeof(unichar) * (size + 1));
     
-    for (sint32 i = 0; i < size; i++) {
+    for (int32_t i = 0; i < size; i++) {
         c[i] = [self readInt16];
         
         if (c[i] == 0) {
@@ -229,8 +229,8 @@
 }
 
 // 4 bytes (length), followed either by string or (if length is zero) 4-byte classID
-- (NSString*)readPSDStringOrGetFourByteID:(uint32*)outId {
-    sint32 size = [self readInt32];
+- (NSString*)readPSDStringOrGetFourByteID:(uint32_t*)outId {
+    int32_t size = [self readInt32];
     
     if (size <= 0) {
         *outId = [self readInt32];
@@ -251,7 +251,7 @@
 
 - (NSString*)readPSDString {
     
-    uint32 size = [self readInt32];
+    uint32_t size = [self readInt32];
     
     if (size == 0) {
         size = 4;
@@ -260,7 +260,7 @@
     return [self readPSDStringOfLength:size];
 }
 
-- (NSString*)readPSDStringOfLength:(uint32)size {
+- (NSString*)readPSDStringOfLength:(uint32_t)size {
     
     char *c = malloc(sizeof(char) * (size + 1));
     
@@ -283,7 +283,7 @@
 
 - (NSString*)readPascalString {
     
-    uint8 size = [self readInt8];
+    uint8_t size = [self readInt8];
     // Name: Pascal string, padded to make the size even (a null name consists of two bytes of 0)
     if((size & 0x01) == 0) {
         size ++;
@@ -347,39 +347,39 @@
     return data;
 }
 
-- (void)writeInt64:(uint64)value {
-    uint64 writeV = CFSwapInt64HostToBig(value);
+- (void)writeInt64:(uint64_t)value {
+    uint64_t writeV = CFSwapInt64HostToBig(value);
     [_outputStream write:(const uint8_t *)&writeV maxLength:8];
     _location += 8;
 }
 
-- (void)writeInt32:(uint32)value {
-    uint32 writeV = CFSwapInt32HostToBig(value);
+- (void)writeInt32:(uint32_t)value {
+    uint32_t writeV = CFSwapInt32HostToBig(value);
     [_outputStream write:(const uint8_t *)&writeV maxLength:4];
     _location += 4;
 }
 
-- (void)writeInt16:(uint16)value {
-    uint32 writeV = CFSwapInt16HostToBig(value);
+- (void)writeInt16:(uint16_t)value {
+    uint32_t writeV = CFSwapInt16HostToBig(value);
     [_outputStream write:(const uint8_t *)&writeV maxLength:2];
     _location += 2;
 }
 
 
-- (void)writeSInt16:(sint16)value {
-    uint32 writeV = CFSwapInt16HostToBig(value);
+- (void)writeSInt16:(int16_t)value {
+    uint32_t writeV = CFSwapInt16HostToBig(value);
     [_outputStream write:(const uint8_t *)&writeV maxLength:2];
     _location += 2;
 }
 
-- (void)writeInt8:(uint8)value {
+- (void)writeInt8:(uint8_t)value {
     [_outputStream write:(const uint8_t *)&value maxLength:1];
     _location += 1;
 }
 
 - (void)writeDataWithLengthHeader:(NSData*)data {
     
-    [self writeInt32:(uint32)[data length]];
+    [self writeInt32:(uint32_t)[data length]];
     
     if ([data length] == 0) {
         return;

--- a/fmpsd/classes/FMPSDTextEngineParser.m
+++ b/fmpsd/classes/FMPSDTextEngineParser.m
@@ -13,24 +13,24 @@
 @property (strong) NSData *engineData;
 @property (assign) NSInteger loc;
 @property (assign) NSInteger len;
-@property (assign) uint8 *base;
+@property (assign) uint8_t *base;
 @property (strong) NSMutableAttributedString *attString;
 @end
 
 @implementation FMPSDTextEngineParser
 
-- (uint8)nextChar {
+- (uint8_t)nextChar {
     char c = _base[_loc];
     _loc++;
     return c;
 }
 
-- (uint16)nextShort {
+- (uint16_t)nextShort {
     
-    uint16 *u = (uint16*)&(_base[_loc]);
+    uint16_t *u = (uint16_t*)&(_base[_loc]);
     
     //uint16 c = CFSwapInt16HostToBig(u[0]);
-    uint16 c = CFSwapInt16BigToHost(u[0]);
+    uint16_t c = CFSwapInt16BigToHost(u[0]);
     _loc += 2;
     
     return c;
@@ -38,10 +38,10 @@
 
 - (NSString*)parseTextTag {
     
-    uint8 op = [self nextChar];
+    uint8_t op = [self nextChar];
     FMAssert(op == '(');
     
-    uint16 bom = [self nextShort];
+    uint16_t bom = [self nextShort];
     FMAssert(bom == 0xfeff);
     
     NSMutableString *ret = [NSMutableString string];
@@ -49,18 +49,18 @@
     // Th\is is\r(a) text läyeז.
     while (_loc < _len) {
         
-        uint16 s = [self nextShort];
+        uint16_t s = [self nextShort];
         
         // debug(@"s: %C / %d", s, s);
         
         if (s == '\\') {
             
-            uint8 asc = [self nextChar];
+            uint8_t asc = [self nextChar];
             [ret appendFormat:@"%c", asc];
         }
         else if (s == 0x000d/*\r*/) {
             
-            uint8 cp = [self nextChar];
+            uint8_t cp = [self nextChar];
             
             if (cp == ')') {
                 // we're done.
@@ -117,7 +117,7 @@
     }
     
     
-    uint8 *startS =_base + startLoc;
+    uint8_t *startS =_base + startLoc;
     
     NSString *ret = [[NSString alloc] initWithBytes:startS length:endLoc-startLoc encoding:NSUTF8StringEncoding];
     
@@ -152,7 +152,7 @@
         return nil;
     }
     
-    uint8 *startS =_base + startTagLoc;
+    uint8_t *startS =_base + startTagLoc;
     
     NSString *ret = [[NSString alloc] initWithBytes:startS length:endTagLoc-startTagLoc encoding:NSUTF8StringEncoding];
     
@@ -460,7 +460,7 @@
     _len = [engineData length];
     _loc = 0;
     
-    _base = (uint8 *)[engineData bytes];
+    _base = (uint8_t *)[engineData bytes];
     
     
     NSDictionary *d = [self parseDictionaryWithName:@"Base"];

--- a/fmpsd/classes/FMPSDUtils.h
+++ b/fmpsd/classes/FMPSDUtils.h
@@ -31,11 +31,11 @@ typedef struct _FMPSDPixel {
 #endif
 } FMPSDPixel;
 
-NSRect FMPSDCGImageGetRect(CGImageRef img);
+CGRect FMPSDCGImageGetRect(CGImageRef img);
 
-CGContextRef FMPSDCGBitmapContextCreate(NSSize size, CGColorSpaceRef cs);
+CGContextRef FMPSDCGBitmapContextCreate(CGSize size, CGColorSpaceRef cs);
 
-FMPSDPixel FMPSDPixelForPointInContext(CGContextRef context, NSPoint point);
+FMPSDPixel FMPSDPixelForPointInContext(CGContextRef context, CGPoint point);
 
 FOUNDATION_STATIC_INLINE FMPSDPixel FMPSDUnPremultiply(FMPSDPixel p) {
     

--- a/fmpsd/classes/FMPSDUtils.h
+++ b/fmpsd/classes/FMPSDUtils.h
@@ -6,7 +6,7 @@
 //  Copyright 2010 Flying Meat Inc. All rights reserved.
 //
 
-#import <Cocoa/Cocoa.h>
+#import <Foundation/Foundation.h>
 
 
 @interface FMPSDUtils : NSObject {

--- a/fmpsd/classes/FMPSDUtils.m
+++ b/fmpsd/classes/FMPSDUtils.m
@@ -23,7 +23,7 @@
 }
 
 
-+ (void)writeComposite:(CIImage*)img colorSpace:(CGColorSpaceRef)cs withBounds:(NSRect)bounds toPath:(NSString*)path {
++ (void)writeComposite:(CIImage*)img colorSpace:(CGColorSpaceRef)cs withBounds:(CGRect)bounds toPath:(NSString*)path {
     
     //kCIImageColorSpace
     
@@ -72,7 +72,7 @@
     
     NSImage *compareTo = [[NSImage alloc] initByReferencingURL:pathURL];
     NSBitmapImageRep *rep  = (id)[[compareTo representations] lastObject];
-    NSRect r = NSMakeRect(0, 0, [rep pixelsWide], [rep pixelsHigh]);
+    CGRect r = CGRectMake(0, 0, [rep pixelsWide], [rep pixelsHigh]);
     
     NSString *tempPath = [NSString stringWithFormat:@"/private/tmp/%@.tiff", [self stringWithUUID]];
     
@@ -95,8 +95,8 @@
     CFRelease(imageSourceRefB);
     
     CGSize size         = CGSizeMake(CGImageGetWidth(imageRefA), CGImageGetHeight(imageRefA));
-    CGContextRef ctxA   = FMPSDCGBitmapContextCreate(NSSizeFromCGSize(size), CGImageGetColorSpace(imageRefA));
-    CGContextRef ctxB   = FMPSDCGBitmapContextCreate(NSSizeFromCGSize(size), CGImageGetColorSpace(imageRefB));
+    CGContextRef ctxA   = FMPSDCGBitmapContextCreate(size, CGImageGetColorSpace(imageRefA));
+    CGContextRef ctxB   = FMPSDCGBitmapContextCreate(size, CGImageGetColorSpace(imageRefB));
     
     CGContextDrawImage(ctxA, FMPSDCGImageGetRect(imageRefA), imageRefA);
     CGContextDrawImage(ctxB, FMPSDCGImageGetRect(imageRefB), imageRefB);
@@ -114,8 +114,8 @@
     for (x = 0; x < size.width; x++) {
         
         for (y = 0; y < size.height; y++) {
-            FMPSDPixel a = FMPSDPixelForPointInContext(ctxA, NSMakePoint(x, y));
-            FMPSDPixel b = FMPSDPixelForPointInContext(ctxB, NSMakePoint(x, y));
+            FMPSDPixel a = FMPSDPixelForPointInContext(ctxA, CGPointMake(x, y));
+            FMPSDPixel b = FMPSDPixelForPointInContext(ctxB, CGPointMake(x, y));
             
             int keyA = a.a;
             int keyR = a.r;
@@ -183,16 +183,16 @@ cleanup:
 
 @end
 
-NSRect FMPSDCGImageGetRect(CGImageRef img) {
+CGRect FMPSDCGImageGetRect(CGImageRef img) {
     if (!img) {
-        return NSZeroRect;
+        return CGRectZero;
     }
     
-    return NSMakeRect(0, 0, CGImageGetWidth(img), CGImageGetHeight(img));
+    return CGRectMake(0, 0, CGImageGetWidth(img), CGImageGetHeight(img));
 }
 
 
-CGContextRef FMPSDCGBitmapContextCreate(NSSize size, CGColorSpaceRef cs) {
+CGContextRef FMPSDCGBitmapContextCreate(CGSize size, CGColorSpaceRef cs) {
     
     FMAssert(cs);
     
@@ -203,8 +203,8 @@ CGContextRef FMPSDCGBitmapContextCreate(NSSize size, CGColorSpaceRef cs) {
     return context;
 }
 
-FMPSDPixel *FMPSDPixelAddressForPointInLocalContext(CGContextRef context, NSPoint p);
-FMPSDPixel *FMPSDPixelAddressForPointInLocalContext(CGContextRef context, NSPoint p) {
+FMPSDPixel *FMPSDPixelAddressForPointInLocalContext(CGContextRef context, CGPoint p);
+FMPSDPixel *FMPSDPixelAddressForPointInLocalContext(CGContextRef context, CGPoint p) {
     
     FMPSDPixel *basePtr   = CGBitmapContextGetData(context);
     
@@ -227,7 +227,7 @@ FMPSDPixel *FMPSDPixelAddressForPointInLocalContext(CGContextRef context, NSPoin
     return (FMPSDPixel *)(basePtr + pt);
 }
 
-FMPSDPixel FMPSDPixelForPointInContext(CGContextRef context, NSPoint point) {
+FMPSDPixel FMPSDPixelForPointInContext(CGContextRef context, CGPoint point) {
     
     FMAssert(CGBitmapContextGetData(context));
     

--- a/fmpsd/classes/FMPSDUtils.m
+++ b/fmpsd/classes/FMPSDUtils.m
@@ -9,6 +9,8 @@
 #import "FMPSD.h"
 #import "FMPSDUtils.h"
 #import <QuartzCore/QuartzCore.h>
+#import <ImageIO/ImageIO.h>
+#import <AppKit/NSImage.h>
 
 @implementation FMPSDUtils
 

--- a/fmpsd/main.m
+++ b/fmpsd/main.m
@@ -8,6 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import <QuartzCore/QuartzCore.h>
+#import <AppKit/NSWorkspace.h>
 #import "FMPSD.h"
 
 


### PR DESCRIPTION
This set of changes (you can see the individual changes by looking at the commits included) remove the use of Cocoa.h, switch to consistently use the `_t` versions of integer types (such as `uint32_t` rather than `uint32`, `int16_t` rather than `sint16`, etc.), and switch from using NS geometry types like `NSRect` to CG types like `CGRect`.

None of these should have an effect on how the code functions, and I successfully built and ran things with Xcode 7 on Mac OS 10.11. To the best of my knowledge, they should be backward compatible.

These changes make it a fairly straightforward matter to add iOS support to FMPSD, which I've also done. I will submit those changes in a separate PR if you'd like, so you have the option of taking this without them.