### PR TITLE
Reading and writing slices

### DIFF
--- a/fmpsd/classes/FMPSD.h
+++ b/fmpsd/classes/FMPSD.h
@@ -63,6 +63,7 @@ extern BOOL FMPSDPrintDebugInfo;
     
     NSData *_colormapData;
     NSData *_iccProfile;
+    NSData *_slices;
     
     FMPSDLayer *_compositeLayer;
     

--- a/fmpsd/classes/FMPSD.m
+++ b/fmpsd/classes/FMPSD.m
@@ -474,10 +474,12 @@ BOOL FMPSDPrintDebugInfo = NO;
         [resourceInfoStream writePascalString:@"" withPadding:2];
         [resourceInfoStream writeDataWithLengthHeader:[self resoultionData]];
         
-        [resourceInfoStream writeInt32:'8BIM'];
-        [resourceInfoStream writeInt16:1050]; // slices info
-        [resourceInfoStream writePascalString:@"" withPadding:2];
-        [resourceInfoStream writeDataWithLengthHeader:_slices];
+        if (_slices.length) {
+            [resourceInfoStream writeInt32:'8BIM'];
+            [resourceInfoStream writeInt16:1050]; // slices info
+            [resourceInfoStream writePascalString:@"" withPadding:2];
+            [resourceInfoStream writeDataWithLengthHeader:_slices];
+        }
         
         [resourceInfoStream writeInt32:'8BIM'];
         [resourceInfoStream writeInt16:1026]; // layer group info

--- a/fmpsd/classes/FMPSD.m
+++ b/fmpsd/classes/FMPSD.m
@@ -277,6 +277,9 @@ BOOL FMPSDPrintDebugInfo = NO;
             //debug(@"[Layers group information]: '%@'", [stream readDataOfLength:sizeofdata]);
             [stream skipLength:sizeofdata];
         }
+        else if (uID == 1050) { // slices
+            _slices = [stream readDataOfLength:sizeofdata];
+        }
         else {
             [stream skipLength:sizeofdata];
         }
@@ -470,6 +473,11 @@ BOOL FMPSDPrintDebugInfo = NO;
         [resourceInfoStream writeInt16:1005]; // resolution info.
         [resourceInfoStream writePascalString:@"" withPadding:2];
         [resourceInfoStream writeDataWithLengthHeader:[self resoultionData]];
+        
+        [resourceInfoStream writeInt32:'8BIM'];
+        [resourceInfoStream writeInt16:1050]; // slices info
+        [resourceInfoStream writePascalString:@"" withPadding:2];
+        [resourceInfoStream writeDataWithLengthHeader:_slices];
         
         [resourceInfoStream writeInt32:'8BIM'];
         [resourceInfoStream writeInt16:1026]; // layer group info


### PR DESCRIPTION
I have an application using fmpsd and I needed to keep the original slices from the PSD files when writing them, even though I don't need to actually see or edit the slices in the app. To solve this I made this simple patch, it reads the slice information from the PSD and keeps it around, writing it back to the file later.