### PR TITLE
Farious fixes from Linea Sketch

### DIFF
--- a/fmpsd/classes/FMABR.m
+++ b/fmpsd/classes/FMABR.m
@@ -112,7 +112,9 @@ extern BOOL FMPSDPrintDebugInfo;
     
     if (_version < 6) {
         NSLog(@"FMABR Doesn't support brush versions less than 6");
-        *err = [NSError errorWithDomain:@"8BPS" code:1 userInfo:@{NSLocalizedDescriptionKey: @"ABR format is too old"}];
+        if (err) {
+            *err = [NSError errorWithDomain:@"8BPS" code:1 userInfo:@{NSLocalizedDescriptionKey: @"ABR format is too old"}];
+        }
         return NO;
     }
     

--- a/fmpsd/classes/FMPSD.h
+++ b/fmpsd/classes/FMPSD.h
@@ -23,6 +23,9 @@
     #define FMAssert(...)
 #endif
 
+#define FMUnused(x) (void)x
+    // For tagging unused variable (in release version) to avoid warning
+
 
 #define TSDebug(...) { if (TSDebugOn) { NSLog(__VA_ARGS__); } }
 
@@ -84,8 +87,8 @@ extern BOOL FMPSDPrintDebugInfo;
 @property (retain) FMPSDLayer *baseLayerGroup;
 @property (assign) BOOL compressLayerData;
 
-+ (id)imageWithContetsOfURL:(NSURL*)fileURL error:(NSError *__autoreleasing *)err;
-+ (id)imageWithContetsOfURL:(NSURL*)fileURL error:(NSError *__autoreleasing *)err printDebugInfo:(BOOL)debugInfo;
++ (instancetype)imageWithContentsOfURL:(NSURL*)fileURL error:(NSError *__autoreleasing *)err;
++ (instancetype)imageWithContentsOfURL:(NSURL*)fileURL error:(NSError *__autoreleasing *)err printDebugInfo:(BOOL)debugInfo;
 + (void)printDebugInfoForFileAtURL:(NSURL*)fileURL;
 
 - (uint16_t)version;
@@ -96,7 +99,7 @@ extern BOOL FMPSDPrintDebugInfo;
 
 - (void)setSavingCompositeImageRef:(CGImageRef)img;
 
-- (CGColorSpaceRef)colorSpace;
+@property CGColorSpaceRef colorSpace;
 
 @end
 

--- a/fmpsd/classes/FMPSDDescriptor.m
+++ b/fmpsd/classes/FMPSDDescriptor.m
@@ -31,11 +31,11 @@
 }
 
 - (id)init {
-	self = [super init];
-	if (self != nil) {
-		_attributes = [NSMutableDictionary dictionary];
-	}
-	return self;
+    self = [super init];
+    if (self != nil) {
+        _attributes = [NSMutableDictionary dictionary];
+    }
+    return self;
 }
 
 - (void)readEnumFromStream:(FMPSDStream*)stream {
@@ -68,7 +68,7 @@
     // ClassID: 4 bytes (length), followed either by string or (if length is zero) 4-byte classID
     uint32_t enumClassID;
     NSString *enumClassIDString   = [stream readPSDStringOrGetFourByteID:&enumClassID];
-    (void)enumClassIDString;
+    FMUnused(enumClassIDString);
     
     debug(@"enumClassIDString: '%@'", enumClassIDString);
     debug(@"enumClassID: %@", FMPSDStringForHFSTypeCode(enumClassID));
@@ -193,7 +193,7 @@
         else if (type == 'AntA') {
             
             uint32_t enumTag = [stream readInt32];
-            (void)enumTag;
+            FMUnused(enumTag);
             FMAssert(enumTag == 'enum');
             
             uint32_t junkIntKey = 0;
@@ -218,21 +218,23 @@
             FMAssert(enumTag == 'enum');
             
             NSString *textGriddingString = [stream readPSDString];
-            (void)textGriddingString;
+            FMUnused(textGriddingString);
             FMAssert([textGriddingString isEqualToString:@"textGridding"]);
             
             enumTag = 0;
             NSString *textGriddingTagTypeStringWhatever = [stream readPSDStringOrGetFourByteID:&enumTag];
-            (void)textGriddingTagTypeStringWhatever;
+            FMUnused(textGriddingTagTypeStringWhatever);
+            
             FMAssert(textGriddingTagTypeStringWhatever == NULL);
             
             FMAssert(enumTag == 'None' || enumTag == 'Rnd '); // OK, what other text gridding types are there?
-			
+            
         }
         else if ([key isEqualToString:@"bounds"] || [key isEqualToString:@"boundingBox"]) {
             
             uint32_t boundsKey = [stream readInt32];
-            (void)boundsKey;
+            FMUnused(boundsKey);
+            
             FMAssert(boundsKey == 'Objc');
             
             FMPSDDescriptor *d = [FMPSDDescriptor descriptorWithStream:stream psd:_psd];
@@ -272,7 +274,7 @@
         else if ([key isEqualToString:@"warpStyle"] || [key isEqualToString:@"warpRotate"]) {
             
             uint32_t enumTag = [stream readInt32];
-            (void)enumTag;
+            FMUnused(enumTag);
             FMAssert(enumTag == 'enum');
             
             uint32_t junkIntKey = 0;
@@ -288,11 +290,12 @@
         else if ([key isEqualToString:@"warpValue"] || [key isEqualToString:@"warpPerspective"] || [key isEqualToString:@"warpPerspectiveOther"]) {
             
             uint32_t enumTag = [stream readInt32];
-            (void)enumTag;
+            FMUnused(enumTag);
             FMAssert(enumTag == 'doub');
             
             double val = [stream readDouble64];
-            (void)val;
+            FMUnused(val);
+            
             debug(@"%@: %f", key, val);
             
             /*
@@ -310,7 +313,7 @@
         else if ([key isEqualToString:@"EngineData"]) {
             
             uint32_t tdtaTag = [stream readInt32];
-            (void)tdtaTag;
+            FMUnused(tdtaTag);
             FMAssert(tdtaTag == 'tdta');
             
             debug(@"[stream location]: %ld", [stream location]);
@@ -371,7 +374,7 @@
                  */
                  
                 uint32_t unitType = [stream readInt32];
-                (void)unitType;
+                FMUnused(unitType);
                 //NSLog(@"unitType: %@", FMPSDStringForHFSTypeCode(unitType));
                  
                 // #Pnt isn't documented, but I'm going to assume it means "point".
@@ -405,7 +408,7 @@
                 [stream skipLength:4];
                 
                 uint32_t blendModeTagAgain = [stream readInt32];
-                (void)blendModeTagAgain;
+                FMUnused(blendModeTagAgain);
                 [stream skipLength:4];
                 
                 FMAssert(blendModeTagAgain == 'BlnM');

--- a/fmpsd/classes/FMPSDLayer.h
+++ b/fmpsd/classes/FMPSDLayer.h
@@ -69,11 +69,11 @@
 @property (assign) BOOL printDebugInfo;
 @property (assign) uint32_t blendMode;
 @property (retain) NSDictionary *textProperties;
+@property CGImageRef image;
 
-
-+ (id)layerWithStream:(FMPSDStream*)stream psd:(FMPSD*)psd error:(NSError *__autoreleasing *)err;
-+ (id)layerWithSize:(CGSize)s psd:(FMPSD*)psd;
-+ (id)baseLayer;
++ (instancetype)layerWithStream:(FMPSDStream*)stream psd:(FMPSD*)psd error:(NSError *__autoreleasing *)err;
++ (instancetype)layerWithSize:(CGSize)s psd:(FMPSD*)psd;
++ (instancetype)baseLayer;
 
 - (BOOL)readImageDataFromStream:(FMPSDStream*)stream lineLengths:(uint16_t *)lineLengths needReadPlanInfo:(BOOL)needsPlaneInfo error:(NSError *__autoreleasing *)err;
 - (void)writeLayerInfoToStream:(FMPSDStream*)stream;
@@ -83,8 +83,6 @@
 - (void)setFrame:(CGRect)frame;
 - (void)setMaskFrame:(CGRect)frame;
 - (CGRect)maskFrame;
-- (CGImageRef)image;
-- (void)setImage:(CGImageRef)anImage;
 - (CGImageRef)mask;
 - (void)setMask:(CGImageRef)value;
 - (uint8_t)maskColor;

--- a/fmpsd/classes/FMPSDTextEngineParser.m
+++ b/fmpsd/classes/FMPSDTextEngineParser.m
@@ -39,12 +39,12 @@
 - (NSString*)parseTextTag {
     
     uint8_t op = [self nextChar];
-    (void)op;
     FMAssert(op == '(');
+    FMUnused(op);
     
     uint16_t bom = [self nextShort];
-    (void)bom;
     FMAssert(bom == 0xfeff);
+    FMUnused(bom);
     
     NSMutableString *ret = [NSMutableString string];
     
@@ -243,7 +243,7 @@
     
     [self scanToChar:'<'];
     char c = [self nextChar];
-    (void)c;
+    FMUnused(c);
     FMAssert(c == '<');
     
 }
@@ -251,7 +251,7 @@
 - (void)scanToDoubleGreaterThan {
     [self scanToChar:'>'];
     char c = [self nextChar];
-    (void)c;
+    FMUnused(c);
     FMAssert(c == '>');
 }
 
@@ -267,7 +267,8 @@
     NSMutableDictionary *currentDict = [NSMutableDictionary dictionary];
     
     char c = [self nextChar];
-    (void)c;
+    FMUnused(c);
+    
     FMAssert(c == '[');
     
     NSString *restOfLine = [self scanToEndOfLine];
@@ -376,7 +377,7 @@
     // dicts start out with a << on their own line, and end with a >>?
     
     NSString *startB = [self scanNextWord];
-    (void)startB;
+    FMUnused(startB);
     FMAssert([startB isEqualToString:@"<<"]);
     
     NSString *key = [self scanNextWord];

--- a/fmpsd/classes/FMPSDUtils.m
+++ b/fmpsd/classes/FMPSDUtils.m
@@ -286,10 +286,10 @@ void FMPSDDecodeRLE(char *src, int sindex, int slen, char *dst, int dindex) {
 NSString * FMPSDStringForHFSTypeCode(OSType hfsFileTypeCode) {
     
     return [NSString stringWithFormat:@"%c%c%c%c",
-                (hfsFileTypeCode >> 24) & 0xFF,
-                (hfsFileTypeCode >> 16) & 0xFF,
-                (hfsFileTypeCode >>  8) & 0xFF,
-                (hfsFileTypeCode      ) & 0xFF];
+                (int) (hfsFileTypeCode >> 24) & 0xFF,
+                (int) (hfsFileTypeCode >> 16) & 0xFF,
+                (int) (hfsFileTypeCode >>  8) & 0xFF,
+                (int) (hfsFileTypeCode      ) & 0xFF];
     
 }
 


### PR DESCRIPTION
Hi--

Do any of these changes that we've made to make FMPSD more Swift friendly, etc... interest you?  I've put them all together now in one bunch, but could split things apart if some but not all of these appeal to you.  These changes are mostly by other members of my teammates at Iconfactory (Troy, Sean, Craig) but I'm trying to make maintenance for myself easier going forward.

Summary of our changes:
• Write the base layer count to PSD as a positive number
• Remove method version after change to property
• Fixed version of building flags via bit shifting (comment)
• Comments to organize writing code
• Write layer data with RLE compression
• Added some comments to mirror PSD file format docs
• Remove method version of property
• Use FMUnused in another place
• Fixed analyzer warning.
• Changed to a property as it is slightly more swift-friendly
• Fixed a typo that bugged me. Added instancetype so the initializer works better with Swift.
• Fixed new iOS 11 warning deprecations
• When using dispatch_apply, make a copy of the width into a local for the block to use.
• Added ability to set the color space to FMPSD.
• Silenced remaining warnings.
• Added FMUnused and use it to tag several places where variables are used only in debug code for asserts (to silence the warnings when building release).
• Commented out NSLog where FMPSDStream would write out the number of bytes whenever it was closed.
• Close memory streams after reading the outputData from them before they are released. Not sure this is necessary, but there was a crash releasing one recorded by TestFlight, so it seems a good precaution to close them explicitly before they exit scope.
• Use `instancetype` as the return type for factory class methods in FMPSDLayer.